### PR TITLE
Rewrite LogOS as lightweight symbolic Python service with web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,44 @@
-# LogOS
-Logical Operating System
+# LogOS (Rewrite)
 
-This is a hobby project in which I aim at creating a conversational machine (chatbot). Hopefully one day it will be able to hold a simple
-conversation. For now it is just an experimental repository where I throw different ideas in (see repo LogosBot as well).
+LogOS is an experiment in **symbolic, resource-efficient conversational reasoning**. The original Java prototype explored NLP and hypergraph ideas inspired by cognitive architectures (Soar, OpenCog, NARS). This rewrite focuses on the same spirit with a much lighter, browser-based interface and a modular symbolic core.
 
-There are two kinds of approaches that I considered: symbolic AI and a simple pattern matching algorithm with a huge amount of hardcoded
-responses to user inputs. So far I've noticed that natural language has so many exceptions from rules that it seems impossible to write
-an elegant algorithm that describes the whole variety of possible sentences without losing "soul" or individual meaning.
+## Goals
 
-I packed symbolic approaches and NLP in `logos` and simple chatbot in `bot`. The latter doesn't even need any external libraries (yet).
+- Prioritize symbolic reasoning and hypergraph-style memory.
+- Use deep learning **only where it is strictly necessary**.
+- Keep the system small, inspectable, and efficient.
 
-As for now I prefer the personal chatbot approach that gives a very good possibility to express myself. That's exactly what I need from
-this project. I don't want to create yet another "soulless" utility maximizer or anything like that. Our world has a lot of that stuff
-already.
+## Quick start
 
-But the simple chatbot isn't totally stupid - it's not just a dictionary of responses. The class `StateVariables` will contain a whole
-bunch of data fields that should describe internal and external states. This will allow a primitive context understanding and coreference.
+> Requires Python 3.11+.
 
-My strategy will be just adding at least 10 patterns a day to the huge `Logos` class. Let's see where this will take me.
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Open <http://localhost:8000> in your browser.
+
+## Module map (rewrite)
+
+| Module | Purpose |
+| --- | --- |
+| `app/main.py` | FastAPI server that hosts the browser UI and exposes `/api/chat`. |
+| `logos/engine.py` | Orchestrates parsing, memory updates, and response selection. |
+| `logos/nlp.py` | Lightweight parsing and intent extraction (no heavy ML). |
+| `logos/memory.py` | Stores symbolic facts with indexing for efficient lookup. |
+| `logos/hypergraph.py` | Minimal hypergraph structure to store relations. |
+| `logos/reasoner.py` | Rule-based response generation over symbolic memory. |
+| `logos/state.py` | Conversation state (name, mood, recent topics). |
+| `web/` | Static browser UI for the chat experience. |
+
+## Architecture notes
+
+- The chat loop is designed to stay cheap: tokenization, heuristics, and symbolic memory are enough for many conversational goals.
+- You can integrate deeper NLP or embeddings later, but only where symbolic reasoning fails.
+
+## Legacy code
+
+The original Java prototype lives under `src/` and remains available for reference. The rewrite lives in the top-level `app/`, `logos/`, and `web/` folders.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from logos.engine import ChatEngine
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+WEB_DIR = BASE_DIR / "web"
+
+app = FastAPI(title="LogOS", version="2.0")
+engine = ChatEngine()
+
+app.mount("/static", StaticFiles(directory=WEB_DIR), name="static")
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+@app.get("/", response_class=HTMLResponse)
+def index() -> HTMLResponse:
+    return HTMLResponse((WEB_DIR / "index.html").read_text(encoding="utf-8"))
+
+
+@app.post("/api/chat")
+def chat(request: ChatRequest) -> dict:
+    response = engine.process(request.message)
+    return {"reply": response.reply, "facts": response.facts}

--- a/logos/__init__.py
+++ b/logos/__init__.py
@@ -1,0 +1,1 @@
+"""LogOS rewrite: lightweight symbolic reasoning core."""

--- a/logos/engine.py
+++ b/logos/engine.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from .hypergraph import Hypergraph
+from .memory import Fact, Memory
+from .nlp import ParsedIntent, extract_intent
+from .reasoner import Reasoner
+from .state import ConversationState
+
+
+@dataclass
+class ChatResponse:
+    reply: str
+    facts: Dict[str, str]
+
+
+class ChatEngine:
+    """Coordinates parsing, memory updates, and symbolic reasoning."""
+
+    def __init__(self) -> None:
+        self._state = ConversationState()
+        self._memory = Memory()
+        self._graph = Hypergraph()
+        self._reasoner = Reasoner(self._memory, self._state)
+
+    def process(self, message: str) -> ChatResponse:
+        intent = extract_intent(message)
+        if intent.kind in {"introduce", "state", "preference", "remember"}:
+            reply = self._handle_fact(intent)
+        elif intent.kind == "query" and intent.subject:
+            reply = self._reasoner.respond_to_query(intent.subject)
+        elif intent.kind == "freeform":
+            reply = self._handle_freeform(message)
+        else:
+            reply = self._reasoner.small_talk()
+
+        return ChatResponse(reply=reply, facts=self._facts_snapshot())
+
+    def _handle_fact(self, intent: ParsedIntent) -> str:
+        subject = intent.subject or "user"
+        relation = intent.relation or "says"
+        obj = intent.obj or ""
+        fact = Fact(subject=subject, relation=relation, obj=obj)
+        self._memory.add_fact(fact)
+        self._graph.add_edge(relation, [subject, obj])
+
+        if relation == "name" and subject == "user":
+            self._state.user_name = obj
+            return f"Nice to meet you, {obj}."
+        if relation == "likes":
+            self._state.remember_topic(obj)
+            return f"I will remember that you like {obj}."
+        if relation == "is" and subject == "user":
+            self._state.mood = obj
+            return f"Thanks for sharing that you are {obj}."
+        return "Got it. I have stored that as a symbolic fact."
+
+    def _handle_freeform(self, message: str) -> str:
+        tokens = [token for token in message.split() if token]
+        if tokens:
+            self._state.remember_topic(tokens[-1])
+        return "I am tracking the topic. You can tell me a fact or ask what I know about something."
+
+    def _facts_snapshot(self) -> Dict[str, str]:
+        return {f"{fact.subject}:{index}": f"{fact.relation} {fact.obj}" for index, fact in enumerate(self._memory.all_facts())}

--- a/logos/hypergraph.py
+++ b/logos/hypergraph.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+
+
+@dataclass(frozen=True)
+class Node:
+    label: str
+
+
+@dataclass
+class Edge:
+    relation: str
+    nodes: List[Node] = field(default_factory=list)
+    confidence: float = 1.0
+
+
+class Hypergraph:
+    """Lightweight hypergraph for symbolic relations."""
+
+    def __init__(self) -> None:
+        self._nodes: Dict[str, Node] = {}
+        self._edges: List[Edge] = []
+
+    def node(self, label: str) -> Node:
+        key = label.strip().lower()
+        if key not in self._nodes:
+            self._nodes[key] = Node(label=label.strip())
+        return self._nodes[key]
+
+    def add_edge(self, relation: str, node_labels: Iterable[str], confidence: float = 1.0) -> Edge:
+        nodes = [self.node(label) for label in node_labels]
+        edge = Edge(relation=relation, nodes=nodes, confidence=confidence)
+        self._edges.append(edge)
+        return edge
+
+    def edges(self) -> List[Edge]:
+        return list(self._edges)

--- a/logos/memory.py
+++ b/logos/memory.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class Fact:
+    subject: str
+    relation: str
+    obj: str
+    confidence: float = 1.0
+
+
+class Memory:
+    """Stores symbolic facts with simple indexing."""
+
+    def __init__(self) -> None:
+        self._facts: List[Fact] = []
+        self._by_subject: Dict[str, List[Fact]] = {}
+
+    def add_fact(self, fact: Fact) -> None:
+        self._facts.append(fact)
+        key = fact.subject.lower()
+        self._by_subject.setdefault(key, []).append(fact)
+
+    def facts_about(self, subject: str) -> List[Fact]:
+        return list(self._by_subject.get(subject.lower(), []))
+
+    def all_facts(self) -> List[Fact]:
+        return list(self._facts)

--- a/logos/nlp.py
+++ b/logos/nlp.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+STOP_WORDS = {"a", "an", "the", "to", "of", "and", "in", "on", "for", "with"}
+
+
+@dataclass(frozen=True)
+class ParsedIntent:
+    kind: str
+    subject: Optional[str] = None
+    relation: Optional[str] = None
+    obj: Optional[str] = None
+
+
+def tokenize(text: str) -> List[str]:
+    return [token.strip(".,!?;:").lower() for token in text.split() if token.strip(".,!?;:")]
+
+
+def extract_intent(text: str) -> ParsedIntent:
+    lowered = text.strip().lower()
+
+    if lowered.startswith("my name is "):
+        return ParsedIntent(kind="introduce", subject="user", relation="name", obj=text.strip()[11:])
+
+    if lowered.startswith("i am "):
+        return ParsedIntent(kind="state", subject="user", relation="is", obj=text.strip()[5:])
+
+    if lowered.startswith("i like "):
+        return ParsedIntent(kind="preference", subject="user", relation="likes", obj=text.strip()[7:])
+
+    if lowered.startswith("remember "):
+        payload = text.strip()[9:]
+        return ParsedIntent(kind="remember", subject="user", relation="notes", obj=payload)
+
+    if lowered.startswith("what do you know about "):
+        subject = text.strip()[23:]
+        return ParsedIntent(kind="query", subject=subject)
+
+    if lowered in {"who am i", "who am i?"}:
+        return ParsedIntent(kind="query", subject="user")
+
+    tokens = [token for token in tokenize(text) if token not in STOP_WORDS]
+    if len(tokens) >= 3 and tokens[0] == "i":
+        return ParsedIntent(kind="state", subject="user", relation=tokens[1], obj=" ".join(tokens[2:]))
+
+    return ParsedIntent(kind="freeform")

--- a/logos/reasoner.py
+++ b/logos/reasoner.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import List
+
+from .memory import Fact, Memory
+from .state import ConversationState
+
+
+class Reasoner:
+    """Rule-based response selection over symbolic memory."""
+
+    def __init__(self, memory: Memory, state: ConversationState) -> None:
+        self._memory = memory
+        self._state = state
+
+    def respond_to_query(self, subject: str) -> str:
+        facts = self._memory.facts_about(subject)
+        if not facts:
+            return f"I do not have any facts about {subject} yet."
+        summaries = self._summarize_facts(facts)
+        return f"Here is what I know about {subject}: {summaries}"
+
+    def _summarize_facts(self, facts: List[Fact]) -> str:
+        snippets = [f"{fact.relation} {fact.obj}" for fact in facts]
+        return "; ".join(snippets)
+
+    def small_talk(self) -> str:
+        if self._state.user_name:
+            return f"How is your day going, {self._state.user_name}?"
+        return "Tell me something about yourself."

--- a/logos/state.py
+++ b/logos/state.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class ConversationState:
+    user_name: str | None = None
+    mood: str | None = None
+    last_topics: List[str] = field(default_factory=list)
+
+    def remember_topic(self, topic: str) -> None:
+        if topic and topic not in self.last_topics:
+            self.last_topics.append(topic)
+        if len(self.last_topics) > 5:
+            self.last_topics.pop(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+pydantic==2.9.2

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LogOS — Symbolic Chat</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header>
+        <h1>LogOS</h1>
+        <p>Symbolic, resource-efficient conversational reasoning.</p>
+      </header>
+
+      <section class="chat" id="chat"></section>
+
+      <form class="composer" id="composer">
+        <input
+          type="text"
+          name="message"
+          id="message"
+          placeholder="Say something about yourself or ask a question..."
+          autocomplete="off"
+          required
+        />
+        <button type="submit">Send</button>
+      </form>
+    </main>
+
+    <script>
+      const chat = document.getElementById("chat");
+      const composer = document.getElementById("composer");
+      const messageInput = document.getElementById("message");
+
+      const appendBubble = (text, type) => {
+        const bubble = document.createElement("div");
+        bubble.className = `bubble ${type}`;
+        bubble.textContent = text;
+        chat.appendChild(bubble);
+        chat.scrollTop = chat.scrollHeight;
+      };
+
+      appendBubble("Hi! Tell me about yourself or ask what I know.", "bot");
+
+      composer.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const message = messageInput.value.trim();
+        if (!message) return;
+        appendBubble(message, "user");
+        messageInput.value = "";
+
+        const response = await fetch("/api/chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ message }),
+        });
+        const data = await response.json();
+        appendBubble(data.reply, "bot");
+      });
+    </script>
+  </body>
+</html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,92 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #0f1115;
+  color: #f1f5f9;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.app {
+  width: min(900px, 90vw);
+  background: #151a22;
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 2.2rem;
+}
+
+header p {
+  margin: 6px 0 0;
+  color: #cbd5f5;
+}
+
+.chat {
+  background: #0b0d12;
+  border-radius: 16px;
+  padding: 20px;
+  height: 360px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.bubble {
+  padding: 12px 16px;
+  border-radius: 16px;
+  max-width: 70%;
+  line-height: 1.4;
+}
+
+.bubble.user {
+  background: #2563eb;
+  align-self: flex-end;
+}
+
+.bubble.bot {
+  background: #1f2937;
+  border: 1px solid #2f3645;
+  align-self: flex-start;
+}
+
+.composer {
+  display: flex;
+  gap: 12px;
+}
+
+.composer input {
+  flex: 1;
+  padding: 12px 16px;
+  border-radius: 999px;
+  border: 1px solid #2f3645;
+  background: #0b0d12;
+  color: inherit;
+}
+
+.composer button {
+  padding: 12px 24px;
+  border-radius: 999px;
+  border: none;
+  background: #38bdf8;
+  color: #0b0d12;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.composer button:hover {
+  background: #0ea5e9;
+}


### PR DESCRIPTION
### Motivation
- Modernize the old Java prototype into a small, resource-efficient symbolic core with a browser-based interface to prioritize symbolic/hypergraph reasoning and use deep learning only where necessary.

### Description
- Add a lightweight `logos` package implementing a minimal hypergraph (`logos/hypergraph.py`), symbolic fact memory (`logos/memory.py`), intent extractor (`logos/nlp.py`), conversation state (`logos/state.py`), rule-based reasoner (`logos/reasoner.py`), and an orchestrating chat engine (`logos/engine.py`).
- Add a FastAPI server at `app/main.py` and a static browser UI in `web/index.html` and `web/styles.css` that talk to `/api/chat` for interactive demo usage.
- Add `requirements.txt` with runtime dependencies and update `README.md` with quick start instructions and a module map describing the rewrite and where legacy Java code remains.

### Testing
- Attempted `pip install -r requirements.txt`, but the install failed due to network/proxy restrictions so dependencies could not be installed.
- Attempted to run the server via `uvicorn app.main:app`, but `uvicorn` was not available in the environment and the server could not be started.
- No automated tests were executed because dependency installation and server start were blocked by the environment, so only static code and README changes were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d9d2d1adc8324a9513cdcb9ae825b)